### PR TITLE
Add PV/PVC YAML definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Store the Consul server configuration file in a ConfigMap:
 kubectl create configmap consul --from-file=configs/server.json
 ```
 
+### Create PVC and PV for Consul
+
+Create PersistentVolumeClaim and PersistentVolume which Consul uses to store data:
+
+```
+kubectl create -f persistenvolumes/data-consul-0-pv.yaml
+kubectl create -f persistenvolumes/data-consul-0-pvc.yaml
+kubectl create -f persistenvolumes/data-consul-1-pv.yaml
+kubectl create -f persistenvolumes/data-consul-1-pvc.yaml
+kubectl create -f persistenvolumes/data-consul-2-pv.yaml
+kubectl create -f persistenvolumes/data-consul-2-pvc.yaml
+```
+
 ### Create the Consul Service
 
 Create a headless service to expose each Consul member internally to the cluster:

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ kubectl create configmap consul --from-file=configs/server.json
 Create PersistentVolumeClaim and PersistentVolume which Consul uses to store data:
 
 ```
-kubectl create -f persistenvolumes/data-consul-0-pv.yaml
-kubectl create -f persistenvolumes/data-consul-0-pvc.yaml
-kubectl create -f persistenvolumes/data-consul-1-pv.yaml
-kubectl create -f persistenvolumes/data-consul-1-pvc.yaml
-kubectl create -f persistenvolumes/data-consul-2-pv.yaml
-kubectl create -f persistenvolumes/data-consul-2-pvc.yaml
+kubectl create -f persistentvolumes/data-consul-0-pv.yaml
+kubectl create -f persistentvolumes/data-consul-0-pvc.yaml
+kubectl create -f persistentvolumes/data-consul-1-pv.yaml
+kubectl create -f persistentvolumes/data-consul-1-pvc.yaml
+kubectl create -f persistentvolumes/data-consul-2-pv.yaml
+kubectl create -f persistentvolumes/data-consul-2-pvc.yaml
 ```
 
 ### Create the Consul Service

--- a/cleanup
+++ b/cleanup
@@ -7,3 +7,4 @@ kubectl delete svc consul
 kubectl delete jobs consul-join
 kubectl delete secrets consul
 kubectl delete configmaps consul
+kubectl delete pv data-consul-0 data-consul-1 data-consul-2

--- a/persistentvolumes/data-consul-0-pv.yaml
+++ b/persistentvolumes/data-consul-0-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: data-consul-0
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/data0"

--- a/persistentvolumes/data-consul-0-pvc.yaml
+++ b/persistentvolumes/data-consul-0-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-consul-0
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/persistentvolumes/data-consul-1-pv.yaml
+++ b/persistentvolumes/data-consul-1-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: data-consul-1
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/data1"

--- a/persistentvolumes/data-consul-1-pvc.yaml
+++ b/persistentvolumes/data-consul-1-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-consul-1
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/persistentvolumes/data-consul-2-pv.yaml
+++ b/persistentvolumes/data-consul-2-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: data-consul-2
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/data2"

--- a/persistentvolumes/data-consul-2-pvc.yaml
+++ b/persistentvolumes/data-consul-2-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-consul-2
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
Hey @kelseyhightower ,

When following instructions in README.md my first POD enters "Pending" state with message "PersistentVolumeClaim is not bound: data-consul-0".
Therefore, I created PVC/PV YAML definitions, and updated README.md to create PV/PVC before Consul service.
I have tested this on my Kubernetes environment, and it works fine.

Thanks,
Milos