### PR TITLE
Fix port-forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ kubectl logs consul-0
 The consul CLI can also be used to check the health of the cluster. In a new terminal start a port-forward to the `consul-0` pod.
 
 ```
-kubectl port-forward consul-0 8400:8400
+kubectl port-forward consul-0 8400:8400 8500:8500
 ```
 ```
 Forwarding from 127.0.0.1:8400 -> 8400
-Forwarding from [::1]:8400 -> 8400
+Forwarding from 127.0.0.1:8500 -> 8500
 ```
 
 Run the `consul members` command to view the status of each cluster member.


### PR DESCRIPTION
Newer version of the consul cli tool need access to the cluster via the HTTP interface. So this port needs to be forwarded as well.

Without this fix, you get the following error message:
```
consul members
Error retrieving members: Get http://127.0.0.1:8500/v1/agent/members?segment=_all: dial tcp 127.0.0.1:8500: getsockopt: connection refused
```