### PR TITLE
Update to Consul 1.2.0 (now 1.2.2); minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This tutorial leverages features available in Kubernetes 1.6.0 and later.
 
 The following clients must be installed on the machine used to follow this tutorial:
 
-* [consul](https://www.consul.io/downloads.html) 1.2.0
+* [consul](https://www.consul.io/downloads.html) 1.2.1
 * [cfssl](https://pkg.cfssl.org) and [cfssljson](https://pkg.cfssl.org) 1.2
 
 ## Usage
@@ -141,9 +141,9 @@ consul members
 ```
 ```
 Node      Address           Status  Type    Build  Protocol  DC   Segment
-consul-0  10.136.8.78:8301  alive   server  1.2.0  2         dc1  <all>
-consul-1  10.136.7.41:8301  alive   server  1.2.0  2         dc1  <all>
-consul-2  10.136.9.27:8301  alive   server  1.2.0  2         dc1  <all>
+consul-0  10.136.8.78:8301  alive   server  1.2.1  2         dc1  <all>
+consul-1  10.136.7.41:8301  alive   server  1.2.1  2         dc1  <all>
+consul-2  10.136.9.27:8301  alive   server  1.2.1  2         dc1  <all>
 ```
 
 ### Accessing the Web UI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This tutorial leverages features available in Kubernetes 1.6.0 and later.
 
 The following clients must be installed on the machine used to follow this tutorial:
 
-* [consul](https://www.consul.io/downloads.html) 0.9.0
+* [consul](https://www.consul.io/downloads.html) 1.2.0
 * [cfssl](https://pkg.cfssl.org) and [cfssljson](https://pkg.cfssl.org) 1.2
 
 ## Usage
@@ -65,7 +65,7 @@ consul.pem
 [Gossip communication](https://www.consul.io/docs/internals/gossip.html) between Consul members will be encrypted using a shared encryption key. Generate and store an encrypt key:
 
 ```
-GOSSIP_ENCRYPTION_KEY=$(consul keygen)
+export GOSSIP_ENCRYPTION_KEY=$(consul keygen)
 ```
 
 ### Create the Consul Secret and Configmap
@@ -127,11 +127,11 @@ kubectl logs consul-0
 The consul CLI can also be used to check the health of the cluster. In a new terminal start a port-forward to the `consul-0` pod.
 
 ```
-kubectl port-forward consul-0 8400:8400
+kubectl port-forward consul-0 8500:8500
 ```
 ```
-Forwarding from 127.0.0.1:8400 -> 8400
-Forwarding from [::1]:8400 -> 8400
+Forwarding from 127.0.0.1:8500 -> 8500
+Forwarding from [::1]:8500 -> 8500
 ```
 
 Run the `consul members` command to view the status of each cluster member.
@@ -140,10 +140,10 @@ Run the `consul members` command to view the status of each cluster member.
 consul members
 ```
 ```
-Node      Address           Status  Type    Build  Protocol  DC
-consul-0  10.176.4.30:8301  alive   server  0.7.2  2         dc1
-consul-1  10.176.4.31:8301  alive   server  0.7.2  2         dc1
-consul-2  10.176.1.16:8301  alive   server  0.7.2  2         dc1
+Node      Address           Status  Type    Build  Protocol  DC   Segment
+consul-0  10.136.8.78:8301  alive   server  1.2.0  2         dc1  <all>
+consul-1  10.136.7.41:8301  alive   server  1.2.0  2         dc1  <all>
+consul-2  10.136.9.27:8301  alive   server  1.2.0  2         dc1  <all>
 ```
 
 ### Accessing the Web UI

--- a/configs/server.json
+++ b/configs/server.json
@@ -1,11 +1,22 @@
 {
+  "bind_addr": "0.0.0.0",
   "ca_file": "/etc/tls/ca.pem",
   "cert_file": "/etc/tls/consul.pem",
   "key_file": "/etc/tls/consul-key.pem",
+  "client_addr": "0.0.0.0",
   "verify_incoming": true,
   "verify_outgoing": true,
   "verify_server_hostname": true,
+  "disable_host_node_id": true,
+  "domain": "cluster.local",
+  "data_dir": "/consul/data",
+  "datacenter": "dc1",
+  "telemetry": {
+	  "prometheus_retention_time": "5m"
+  },
   "ports": {
     "https": 8443
-  }
+  },
+  "server": true,
+  "ui": true
 }

--- a/statefulsets/consul.yaml
+++ b/statefulsets/consul.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:1.2.0"
+          image: "consul:1.2.1"
           env:
             - name: POD_IP
               valueFrom:

--- a/statefulsets/consul.yaml
+++ b/statefulsets/consul.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.9.1"
+          image: "consul:1.2.0"
           env:
             - name: POD_IP
               valueFrom:
@@ -40,28 +40,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CONSUL_LOCAL_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: consul
+                  key: server.json
           args:
             - "agent"
             - "-advertise=$(POD_IP)"
-            - "-bind=0.0.0.0"
             - "-bootstrap-expect=3"
             - "-retry-join=consul-0.consul.$(NAMESPACE).svc.cluster.local"
             - "-retry-join=consul-1.consul.$(NAMESPACE).svc.cluster.local"
             - "-retry-join=consul-2.consul.$(NAMESPACE).svc.cluster.local"
-            - "-client=0.0.0.0"
-            - "-config-file=/consul/config/server.json"
-            - "-datacenter=dc1"
-            - "-data-dir=/consul/data"
-            - "-domain=cluster.local"
             - "-encrypt=$(GOSSIP_ENCRYPTION_KEY)"
-            - "-server"
-            - "-ui"
-            - "-disable-host-node-id"
           volumeMounts:
             - name: data
               mountPath: /consul/data
-            - name: config
-              mountPath: /consul/config
             - name: tls
               mountPath: /etc/tls
           lifecycle:
@@ -91,9 +85,6 @@ spec:
             - containerPort: 8300
               name: server
       volumes:
-        - name: config
-          configMap:
-            name: consul
         - name: tls
           secret:
             secretName: consul  


### PR DESCRIPTION
## Primary change: Consul 1.2.0 (now 1.2.1.... 1.2.2...  1.2.3)
Continues to use upstream official consul container; the primary issue in that process is that  [the entrypoint tries to chown the config directory](https://github.com/hashicorp/docker-consul/blob/75d540650a025b682daa8f0760cdce02c5318602/0.X/docker-entrypoint.sh#L85) which doesn't work with mounted config volumes.  So config injection has to go the alternate way suggested on their [dockerhub](https://hub.docker.com/_/consul/) - 

 > Alternatively, configuration can be added by passing the configuration JSON via environment variable CONSUL_LOCAL_CONFIG.

## Secondary changes

* README updated to match.
* Static configuration variables moved from CLI to config file to make them easier to edit.  I can swap these back if you want.
* Prometheus support turned on.  It uses a bare minimum of memory with the 5 minute retention and then the default works with a whole lot of monitoring toolkits that integrate directly into Kubernetes itself.  And FWIW all the others are turned on by default; this just gives Prometheus parity.